### PR TITLE
Add script for ignored files in the working tree

### DIFF
--- a/git-find-ignored-files.sh
+++ b/git-find-ignored-files.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# git-find-ignored-files.sh
+#
+# Find all files present in the index and working tree ignored by .gitignore
+#
+# Usage: git-find-ignored-files [-s | --sort-by-size] [--help]
+#
+# Author: Patrick Lühne, https://www.luehne.de/
+#
+
+function print_help
+{
+	grep "^# Usage" < "$0" | cut -c 3-
+}
+
+if [[ $# -gt 1 ]]
+then
+	print_help
+	exit 1
+fi
+
+command="git ls-files --ignored --exclude-standard -z | xargs -0r du -sh"
+
+case "$1" in
+	-h|--help)
+		print_help
+		exit 0
+		;;
+	-s|--sort-by-size)
+		command="$command | sort -h"
+		;;
+	*)
+		if [[ $# -gt 0 ]]
+		then
+			(>&2 echo "error: unknown option “$1”")
+			print_help
+			exit 1
+		fi
+		;;
+esac
+
+eval "$command"

--- a/git-find-ignored-files.sh
+++ b/git-find-ignored-files.sh
@@ -20,7 +20,15 @@ then
 	exit 1
 fi
 
-command="git ls-files --ignored --exclude-standard -z | xargs -0r du -sh"
+xargs_test_r_option=$((echo | xargs -r ls &> /dev/null); echo $?)
+xargs="xargs -0"
+
+if [[ $xargs_test_r_option -eq 0 ]]
+then
+	xargs="$xargs -r"
+fi
+
+command="git ls-files --ignored --exclude-standard -z | $xargs du -sh"
 
 case "$1" in
 	-h|--help)


### PR DESCRIPTION
This adds a script that lists all files that are ignored by `.gitignore` but present in the worktree nevertheless. The option `--sort-by-size` sorts the output by file size, whereas the default is to sort the files lexicographically with numeric sorting.