### PR TITLE
Speed up git-find-large-files

### DIFF
--- a/git-find-dirs-deleted-files
+++ b/git-find-dirs-deleted-files
@@ -15,7 +15,7 @@
 # Output: [deleted file count] [directory still in HEAD revision?] [directory]
 #
 
-git -c diff.renameLimit=10000 log --diff-filter=D --summary |
+git -c diff.renameLimit=30000 log --diff-filter=D --summary |
     grep ' delete mode ...... ' |
     sed 's/ delete mode ...... //' |
     while read -r F ; do

--- a/git-find-large-files
+++ b/git-find-large-files
@@ -35,6 +35,12 @@ OBJECTS=$(
     | sort -nr
 )
 
+TMP=$(tempfile) || exit
+trap 'rm -f $TMP*' EXIT
+
+git rev-list --all --objects > $TMP.objects
+git rev-list --all --objects --max-count=1 > $TMP.objects.1
+
 for OBJ in $OBJECTS; do
     # extract the compressed size in kilobytes
     COMPRESSED_SIZE=$(($(echo $OBJ | cut -f 1 -d ' ')/1024))
@@ -47,9 +53,9 @@ for OBJ in $OBJECTS; do
     SHA=$(echo $OBJ | cut -f 2 -d ' ')
 
     # find the objects location in the repository tree
-    LOCATION=$(git rev-list --all --objects | grep $SHA | sed "s/$SHA //")
+    LOCATION=$(grep $SHA $TMP.objects | sed "s/$SHA //")
 
-    if git rev-list --all --objects --max-count=1 | grep $SHA >/dev/null; then
+    if grep $SHA $TMP.objects.1 >/dev/null; then
         # Object is in the head revision
         HEAD="Present"
     elif [ -e $LOCATION ]; then
@@ -60,7 +66,9 @@ for OBJ in $OBJECTS; do
         HEAD="Deleted"
     fi
 
-    OUTPUT="$OUTPUT\n$COMPRESSED_SIZE,$HEAD,$LOCATION"
+    echo "$COMPRESSED_SIZE,$HEAD,$LOCATION" >> $TMP.output
 done
 
-echo -e $OUTPUT | column -t -s ','
+column -t -s ',' < $TMP.output
+rm -f $TMP*
+exit 0


### PR DESCRIPTION
git-find-large-files invokes the same two 'git rev-list' commands twice for every file it processes inside the loop.  On my very large repo (5M objects), '--all --objects' takes 40s and '--all --objects --max-count=1' takes 6s.  I changed the script to invoke them once and save to temp files to remove all this overhead.

The script also collects the output in a variable. That makes it hard to introspect to see how far it has progress. I changed it to also use a temp file to collect the results.