### PR TITLE
speed up git-find-large files with binary search

### DIFF
--- a/git-find-large-files
+++ b/git-find-large-files
@@ -38,8 +38,8 @@ OBJECTS=$(
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp/}git-find-large-files.XXXXXX") || exit
 trap "rm -rf '$TMP_DIR'" EXIT
 
-git rev-list --all --objects > "$TMP_DIR/objects"
-git rev-list --all --objects --max-count=1 > "$TMP_DIR/objects.1"
+git rev-list --all --objects | sort > "$TMP_DIR/objects"
+git rev-list --all --objects --max-count=1 | sort > "$TMP_DIR/objects.1"
 
 for OBJ in $OBJECTS; do
     # extract the compressed size in kilobytes
@@ -53,9 +53,9 @@ for OBJ in $OBJECTS; do
     SHA=$(echo $OBJ | cut -f 2 -d ' ')
 
     # find the objects location in the repository tree
-    LOCATION=$(grep $SHA "$TMP_DIR/objects" | sed "s/$SHA //")
+    LOCATION=$(look $SHA "$TMP_DIR/objects" | sed "s/$SHA //")
 
-    if grep $SHA "$TMP_DIR/objects.1" >/dev/null; then
+    if look $SHA "$TMP_DIR/objects.1" >/dev/null; then
         # Object is in the head revision
         HEAD="Present"
     elif [ -e $LOCATION ]; then


### PR DESCRIPTION
Sort the temporary `git rev-list` results and use `look` to read the
result using binary sort.

#### Example benchmark

On a repo with >5 million objects finding the hash is ~1000 faster:

```
time grep 6d2793720d350abdfbf91a286f427429550edc8c unsorted
6d2793720d350abdfbf91a286f427429550edc8c some/file
grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn}  test  5.49s user 0.06s system 99% cpu 5.555 total
```
```
time look 6d2793720d350abdfbf91a286f427429550edc8c sorted
6d2793720d350abdfbf91a286f427429550edc8c some/file
look 6d2793720d350abdfbf91a286f427429550edc8c sorted  0.00s user 0.00s system 86% cpu 0.005 total
```